### PR TITLE
fix central finite difference typo

### DIFF
--- a/src/week2s.jmd
+++ b/src/week2s.jmd
@@ -14,7 +14,7 @@ Questions marked with a ⋆ are meant to be completed without using a computer.
 
 **Problem 1.1⋆** Use Taylor's theorem to derive an error bound for central differences
 $$
-f'(x) ≈ {f(x + h) - f(x - h) \over h}
+f'(x) ≈ {f(x + h) - f(x - h) \over 2h}
 $$
 Find an error bound when implemented in floating point arithmetic, assuming that
 $$


### PR DESCRIPTION
@dlfivefifty Arianna has made me aware of a typo in the statement of the central finite difference in the first problem. This typo seems important enough to fix before the sheet is sent out so I'm making this a separate PR from the WIP solutions. 